### PR TITLE
feat: add documentation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,96 @@
-# html-template-se (develop)
+# html-template-se 📘
 
-Dies ist die Basisstruktur für das GitHub CI/CD Template `html-template-se`.
+## 🔍 Überblick
+HTML/CSS/JS Template mit automatischen Linter- und Formatierungs-Checks
 
-- Branch: `develop`
-- Mini-Demo: Dark Mode Toggle mit HTML/CSS/JS
-- Workflows: `.github/workflows/preview.yml` (für Testing + GitHub Pages Preview)
+## ✨ Features
+### 💬 Kommentare
+- index.js: change the text "current theme: light" into "current theme: dark"
 
-## Demo-Funktion
+### 📤 Exportierte Funktionen
+- Keine exportierten Funktionen gefunden
 
-Einfacher Dark-Mode-Toggle per Button.
+### 📦 Abhängigkeiten
+```json
+{
+  "eslint": "8.57.1",
+  "eslint-config-standard": "17.1.0",
+  "eslint-plugin-import": "2.29.1",
+  "eslint-plugin-n": "16.6.2",
+  "eslint-plugin-promise": "6.4.0",
+  "htmlhint": "1.6.3",
+  "prettier": "3.6.2",
+  "stylelint": "16.23.1",
+  "stylelint-config-recommended": "14.0.1",
+  "stylelint-config-standard": "36.0.1"
+}
+```
 
-## Nächste Schritte
+## 📦 Installation
+```bash
+npm install
+```
 
-→ Entwickle neue Funktionen im Branch `develop`, merge nach `testing`, dann nach `main`.
+## 🚀 Nutzung
+```bash
+# lint:html
+npm run lint:html
+# lint:css
+npm run lint:css
+# lint:js
+npm run lint:js
+# lint
+npm run lint
+# fmt
+npm run fmt
+# fmt:check
+npm run fmt:check
+# test
+npm run test
+# docs:readme
+npm run docs:readme
+```
+
+## 📁 Ordnerstruktur
+```text
+__tests__/
+  example.spec.js
+.dockerignore
+.eslintignore
+.eslintrc.json
+.github/
+  workflows/
+    ci.yml
+    docs.yml
+    preview.yml
+.gitignore
+.htmlhintrc
+.prettierignore
+.prettierrc
+.stylelintignore
+.stylelintrc.json
+docker-compose.yml
+Dockerfile
+docs/
+  wiki/
+    .gitkeep
+index.css
+index.html
+index.js
+package-lock.json
+package.json
+README.md
+scripts/
+  generate-docs.mjs
+```
+
+## ⚙️ CI/CD
+- ci.yml
+- docs.yml
+- preview.yml
+
+## 🤝 Beitragshinweise
+Beiträge sind willkommen! Bitte Issues oder Pull Requests stellen.
+
+## 📄 Lizenz
+Keine Lizenz angegeben.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "npm run lint:html && npm run lint:css && npm run lint:js",
     "fmt": "prettier -w .",
     "fmt:check": "prettier --check .",
-    "test": "echo \"(placeholder for future tests)\" && exit 0"
+    "test": "echo \"(placeholder for future tests)\" && exit 0",
+    "docs:readme": "node scripts/generate-docs.mjs"
   },
   "devDependencies": {
     "eslint": "8.57.1",

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -1,0 +1,163 @@
+import fs from 'node:fs/promises';
+import fssync from 'node:fs';
+import path from 'node:path';
+
+const rootDir = '.';
+
+async function readPackageJson() {
+  const data = await fs.readFile(path.join(rootDir, 'package.json'), 'utf8');
+  return JSON.parse(data);
+}
+
+function extractFromFile(filePath) {
+  const content = fssync.readFileSync(filePath, 'utf8');
+  const ext = path.extname(filePath);
+  let comments = [];
+  let exports = [];
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+    comments = content.match(/\/\/[^\n]*|\/\*[\s\S]*?\*\//g) || [];
+    exports = content.match(/export\s+(?:default\s+)?(?:function|const|class|let|var)|module\.exports\s*=|exports\.[\w]+/g) || [];
+  } else if (ext === '.css') {
+    comments = content.match(/\/\*[\s\S]*?\*\//g) || [];
+  } else if (ext === '.html') {
+    comments = content.match(/<!--([\s\S]*?)-->/g) || [];
+  }
+  return { comments, exports };
+}
+
+function cleanComment(comment) {
+  return comment
+    .replace(/^<!--|-->$/g, '')
+    .replace(/^\/\//, '')
+    .replace(/^\/\*/, '')
+    .replace(/\*\/$/, '')
+    .trim();
+}
+
+function generateTree(dir, prefix = '') {
+  const exclude = new Set(['node_modules', '.git']);
+  const entries = fssync
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => !exclude.has(e.name))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const lines = [];
+  for (const entry of entries) {
+    const line = prefix + entry.name + (entry.isDirectory() ? '/' : '');
+    lines.push(line);
+    if (entry.isDirectory()) {
+      lines.push(
+        generateTree(path.join(dir, entry.name), prefix + '  ')
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  const pkg = await readPackageJson();
+  const { name, description, scripts = {}, dependencies = {}, devDependencies = {} } = pkg;
+
+  const files = ['index.html', 'index.js', 'index.css', '__tests__/example.spec.js'];
+  const commentsData = [];
+  const exportsData = [];
+
+  for (const file of files) {
+    if (!fssync.existsSync(file)) continue;
+    const { comments, exports } = extractFromFile(file);
+    comments.forEach((c) => commentsData.push({ file, comment: cleanComment(c) }));
+    exports.forEach((e) => exportsData.push({ file, exp: e.trim() }));
+  }
+
+  const tree = generateTree(rootDir);
+
+  let workflows = [];
+  try {
+    workflows = await fs.readdir('.github/workflows');
+  } catch {
+    workflows = [];
+  }
+
+  const lines = [];
+  lines.push(`# ${name} 📘`);
+  lines.push('');
+  lines.push(`## 🔍 Überblick`);
+  lines.push(`${description}`);
+  lines.push('');
+
+  lines.push(`## ✨ Features`);
+  lines.push(`### 💬 Kommentare`);
+  if (commentsData.length) {
+    for (const { file, comment } of commentsData) {
+      lines.push(`- ${file}: ${comment}`);
+    }
+  } else {
+    lines.push('- Keine Kommentare gefunden');
+  }
+  lines.push('');
+  lines.push(`### 📤 Exportierte Funktionen`);
+  if (exportsData.length) {
+    for (const { file, exp } of exportsData) {
+      lines.push(`- ${file}: \`${exp}\``);
+    }
+  } else {
+    lines.push('- Keine exportierten Funktionen gefunden');
+  }
+  lines.push('');
+  lines.push('### 📦 Abhängigkeiten');
+  const allDeps = { ...dependencies, ...devDependencies };
+  if (Object.keys(allDeps).length) {
+    lines.push('```json');
+    lines.push(JSON.stringify(allDeps, null, 2));
+    lines.push('```');
+  } else {
+    lines.push('Keine Abhängigkeiten angegeben');
+  }
+  lines.push('');
+
+  lines.push(`## 📦 Installation`);
+  lines.push('```bash');
+  lines.push('npm install');
+  lines.push('```');
+  lines.push('');
+
+  lines.push(`## 🚀 Nutzung`);
+  lines.push('```bash');
+  for (const [name, cmd] of Object.entries(scripts)) {
+    lines.push(`# ${name}`);
+    lines.push(`npm run ${name}`);
+  }
+  lines.push('```');
+  lines.push('');
+
+  lines.push(`## 📁 Ordnerstruktur`);
+  lines.push('```text');
+  lines.push(tree);
+  lines.push('```');
+  lines.push('');
+
+  lines.push(`## ⚙️ CI/CD`);
+  if (workflows.length) {
+    for (const wf of workflows) {
+      lines.push(`- ${wf}`);
+    }
+  } else {
+    lines.push('- Keine Workflows gefunden');
+  }
+  lines.push('');
+
+  lines.push(`## 🤝 Beitragshinweise`);
+  lines.push('Beiträge sind willkommen! Bitte Issues oder Pull Requests stellen.');
+  lines.push('');
+
+  lines.push(`## 📄 Lizenz`);
+  lines.push('Keine Lizenz angegeben.');
+  lines.push('');
+
+  await fs.writeFile('README.md', lines.join('\n'));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add script to generate a structured README from package metadata and source comments
- wire docs:readme command into package.json
- regenerate README with overview, features, usage, structure and CI/CD info

## Testing
- `npm run docs:readme`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689dbd5e0da083239c7538076963325b