### PR TITLE
feat: add docs template filtering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,11 @@ name: Generate Docs (README + Wiki)
 
 on:
   workflow_dispatch:
+    inputs:
+      include-template:
+        description: 'Include template directories'
+        required: false
+        default: 'false'
   push:
     branches: ['main']
 
@@ -56,19 +61,8 @@ jobs:
         if: steps.secretcheck.outputs.missing == 'false'
         run: |
           set -euo pipefail
-          {
-            echo "## REPO TREE"
-            ls -la
-            echo
-            echo "## GIT LOG (last 20)"
-            git --no-pager log --oneline -n 20 || true
-            echo
-            echo "## FILE LIST (recursive)"
-            ls -R || true
-            echo
-            echo "## README (existing, first 350 lines)"
-            [ -f README.md ] && sed -n '1,350p' README.md || true
-          } > repo_context.txt
+          FLAG=${{ github.event.inputs.include-template == 'true' && '--all' || '--user-only' }}
+          node scripts/generate-docs.mjs $FLAG
           echo "Context size:"
           wc -c repo_context.txt || true
 

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -1,0 +1,4 @@
+{
+  "includeTemplate": true,
+  "templateDirs": ["templates", "boilerplate"]
+}

--- a/docs/docs-config.md
+++ b/docs/docs-config.md
@@ -1,0 +1,17 @@
+# Dokumentation der docs-Konfiguration
+
+Die Datei [`docs-config.json`](./docs-config.json) steuert, ob Inhalte aus
+Vorlagenverzeichnissen in generierte Dokumente und den Repository-Kontext
+einfließen.
+
+## Template-Inhalte deaktivieren
+
+1. Öffne `docs/docs-config.json`.
+2. Setze `includeTemplate` auf `false`.
+3. Optional kann das Skript `scripts/generate-docs.mjs` mit der Option
+   `--user-only` aufgerufen werden, um Vorlagen unabhängig von der
+   Konfiguration auszuschließen. Mit `--all` werden alle Verzeichnisse
+   berücksichtigt.
+
+Die Liste `templateDirs` enthält Verzeichnisse, die als Vorlagen behandelt
+werden.

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -1,10 +1,84 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { execSync } from 'node:child_process'
 
-const src = path.join(process.cwd(), 'README.md')
-const destDir = path.join(process.cwd(), 'docs')
-const dest = path.join(destDir, 'README.md')
+const args = process.argv.slice(2)
 
-fs.mkdirSync(destDir, { recursive: true })
-fs.copyFileSync(src, dest)
-console.log('Documentation copied to docs/README.md')
+// Load docs configuration
+const configPath = path.join(process.cwd(), 'docs', 'docs-config.json')
+let config = { includeTemplate: true, templateDirs: [] }
+if (fs.existsSync(configPath)) {
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8'))
+  } catch {
+    console.warn('Could not parse docs-config.json – using defaults')
+  }
+}
+
+// Determine whether template directories should be included
+let includeTemplate = config.includeTemplate
+if (args.includes('--all')) includeTemplate = true
+if (args.includes('--user-only')) includeTemplate = false
+
+const templateDirs = config.templateDirs || []
+
+// Helper to collect file list
+function collectFiles(dir, out = [], base = process.cwd()) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    const rel = path.relative(base, full)
+    if (!includeTemplate && templateDirs.some((t) => rel.startsWith(t))) {
+      continue
+    }
+    if (entry.isDirectory()) {
+      collectFiles(full, out, base)
+    } else {
+      out.push(rel)
+    }
+  }
+  return out
+}
+
+// Copy existing README into docs/ for reference
+const srcReadme = path.join(process.cwd(), 'README.md')
+const docsDir = path.join(process.cwd(), 'docs')
+fs.mkdirSync(docsDir, { recursive: true })
+if (fs.existsSync(srcReadme)) {
+  fs.copyFileSync(srcReadme, path.join(docsDir, 'README.md'))
+}
+
+// Build repository context similar to previous workflow step
+let repoTree = ''
+let gitLog = ''
+try {
+  repoTree = execSync('ls -la', { encoding: 'utf8' })
+  gitLog = execSync('git --no-pager log --oneline -n 20 || true', { encoding: 'utf8' })
+} catch {}
+
+const files = collectFiles(process.cwd()).sort().join('\n')
+
+let readmeSnippet = ''
+if (fs.existsSync('README.md')) {
+  try {
+    readmeSnippet = execSync("sed -n '1,350p' README.md", { encoding: 'utf8' })
+  } catch {}
+}
+
+const context = [
+  '## REPO TREE',
+  repoTree.trim(),
+  '',
+  '## GIT LOG (last 20)',
+  gitLog.trim(),
+  '',
+  '## FILE LIST (recursive)',
+  files,
+  '',
+  '## README (existing, first 350 lines)',
+  readmeSnippet.trim(),
+  '',
+].join('\n')
+
+fs.writeFileSync('repo_context.txt', context)
+console.log('Context written to repo_context.txt')


### PR DESCRIPTION
## Summary
- add docs-config.json to control inclusion of template directories
- read docs-config in generate-docs.mjs and filter file list
- allow docs workflow to include or exclude templates via flag
- document configuration options
- format docs config and script for prettier

## Testing
- `npm run fmt:check`
- `npm run lint` *(fails: htmlhint not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc5e28bfc8323a192e3945c77dba9