### PR TITLE
docs: generate wiki from code

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -104,48 +104,9 @@ jobs:
             exit 1
           fi
 
-      - name: Generate Wiki pages with OpenAI
+      - name: Build Wiki from code comments
         if: steps.secretcheck.outputs.missing == 'false'
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          set -euo pipefail
-          mkdir -p docs/wiki
-
-          gen() {
-            local TOPIC="$1"
-            local FILE="$2"
-            local PROMPT
-            PROMPT=$(cat <<'P'
-          Erstelle eine **deutschsprachige** Wiki-Seite zum folgenden Thema.
-          Zielgruppe: Entwickler. Nutze klare Gliederung, kurze Abschnitte,
-          Beispiele (auch Code), häufige Fehler & Troubleshooting.
-
-            Thema:
-            P
-            )
-            PROMPT="${PROMPT} ${TOPIC}\n\n---\nREPO-KONTEXT:\n$(cat repo_context.txt)"
-
-            RESP=$(curl -sS https://api.openai.com/v1/responses \
-                -H "Authorization: Bearer $OPENAI_API_KEY" \
-                -H "Content-Type: application/json" \
-                -d "$(jq -n --arg model "gpt-5" --arg input "$PROMPT" --argjson max_output_tokens 6000 \
-                '{model:$model, input:$input, max_output_tokens:$max_output_tokens}')" \
-            )
-
-            echo "$RESP" | jq -e '.output_text' > /dev/null
-            echo "$RESP" | jq -r '.output_text' > "docs/wiki/$FILE"
-
-            if [ ! -s "docs/wiki/$FILE" ]; then
-              echo "Wiki generation for '$FILE' returned empty output." >&2
-              exit 1
-            fi
-          }
-
-          gen "Installation & Setup (inkl. Docker Compose und Optionen)" "Installation.md"
-          gen "CI/CD-Workflows (Preview, Lint/Tests, Main-Release, Docs-Automation)" "CI-CD.md"
-          gen "Nutzung & Befehle (npm scripts, Docker-Workflow, Hot-Reload)" "Usage.md"
-          gen "Beitragsregeln (Contributing, Code-Style, PR-Checkliste)" "Contributing.md"
+        run: npm run docs:wiki
 
       - name: Prepare docs branch
         if: steps.secretcheck.outputs.missing == 'false'

--- a/docs/wiki/CI-CD.md
+++ b/docs/wiki/CI-CD.md
@@ -1,0 +1,9 @@
+# CI/CD 🤖
+
+| Workflow      | Beschreibung         |
+| ------------- | -------------------- |
+| `ci.yml`      | Linting und Tests    |
+| `preview.yml` | Docker-Preview       |
+| `docs.yml`    | Doku-Automatisierung |
+
+<span style="color:purple">Automatisierte Abläufe sorgen für Qualität.</span>

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,0 +1,7 @@
+# Contributing 🤝
+
+1. Fork & Branch anlegen
+2. Tests/Linter laufen lassen
+3. Pull Request erstellen
+
+<span style="color:blue">Bitte Prettier und ESLint beachten.</span>

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,27 @@
+# Wiki – html-template-se
+
+HTML/CSS/JS Template mit automatischen Linter- und Formatierungs-Checks
+
+| Metadatum       | Wert  |
+| --------------- | ----- |
+| Version         | 1.0.0 |
+| Kommentarzeilen | 1     |
+
+> change the text "current theme: light" into "current theme: dark"
+
+## Architektur
+
+| Datei        | Beschreibung       |
+| ------------ | ------------------ |
+| `index.html` | Einstieg & Markup  |
+| `index.css`  | Basis-Styling      |
+| `index.js`   | Theme-Toggle-Logik |
+
+<span style="color:green">Dieses Wiki wird automatisch aus dem Code erzeugt.</span>
+
+## Kapitel
+
+- [[Installation]]
+- [[Usage]]
+- [[CI-CD]]
+- [[Contributing]]

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,0 +1,8 @@
+# Installation ⚙️
+
+| Befehl         | Zweck                     |
+| -------------- | ------------------------- |
+| `npm install`  | Dependencies installieren |
+| `npm run lint` | Linting ausführen         |
+
+<span style="color:orange">Tipp:</span> Node.js >= 20 verwenden.

--- a/docs/wiki/Usage.md
+++ b/docs/wiki/Usage.md
@@ -1,0 +1,28 @@
+# Usage ▶️
+
+## Skripte
+
+| `lint:html` | htmlhint . |
+| `lint:css` | stylelint "\*_/_.css" |
+| `lint:js` | eslint . --max-warnings=0 |
+| `lint` | npm run lint:html && npm run lint:css && npm run lint:js |
+| `fmt` | prettier -w . |
+| `fmt:check` | prettier --check . |
+| `test` | echo "(placeholder for future tests)" && exit 0 |
+| `docs:wiki` | node scripts/generate-docs.mjs wiki |
+
+### Theme-Toggle Beispiel
+
+```js
+// change the text "current theme: light" into "current theme: dark"
+
+const themeIndicator = document.getElementById('theme-indicator')
+const toggleBtn = document.getElementById('toggle-btn')
+let isDarkMode = false
+toggleBtn.addEventListener('click', () => {
+  isDarkMode = !isDarkMode
+  document.body.classList.toggle('dark-mode', isDarkMode)
+  themeIndicator.textContent = `Current Theme: ${isDarkMode ? 'Dark' : 'Light'}`
+  document.body.classList.toggle('dark')
+})
+```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "npm run lint:html && npm run lint:css && npm run lint:js",
     "fmt": "prettier -w .",
     "fmt:check": "prettier --check .",
-    "test": "echo \"(placeholder for future tests)\" && exit 0"
+    "test": "echo \"(placeholder for future tests)\" && exit 0",
+    "docs:wiki": "node scripts/generate-docs.mjs wiki"
   },
   "devDependencies": {
     "eslint": "8.57.1",


### PR DESCRIPTION
## Summary
- add buildWiki to generate documentation wiki
- style and populate wiki pages with code comments and project metadata
- integrate wiki generation into docs workflow

## Testing
- `npm test`
- `npm run fmt:check`


------
https://chatgpt.com/codex/tasks/task_e_689dcb025544832381b116a29b959d0c