### PR TITLE
Add markdown style guide and reusable doc components

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Kopiere die README in das Verzeichnis `docs`:
 node scripts/generate-docs.mjs
 ```
 
+## Styleguide
+
+Siehe [docs/style-guide.md](docs/style-guide.md) für Schreib- und Formatierungsregeln.
+
 ## Nächste Schritte
 
 → Entwickle neue Funktionen im Branch `develop`, merge nach `testing`, dann nach `main`.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,38 @@
+# Styleguide
+
+## Überschriften
+- Nutze ATX-Überschriften mit `#` und erhöhe die Ebene nur um eins.
+- Emojis dürfen am Anfang einer Überschrift stehen: `## ✨ Beispiel`.
+
+## Emojis
+- Setze Emojis sparsam, um Inhalte zu betonen.
+- In Listen können sie als visuelle Marker dienen.
+
+## Farbmarkierungen
+- Verwende [Shields.io](https://shields.io/) für farbige Badges.
+- Syntax: `![Status](https://img.shields.io/badge/Status-grün-success)`.
+
+## Tabellen
+```md
+| Spalte | Wert |
+| --- | --- |
+| A | B |
+```
+
+## Codeblöcke
+```js
+console.log('Hallo Welt')
+```
+
+## Komponenten
+Warnhinweis:
+```md
+> [!WARNING]
+> Kritischer Hinweis.
+```
+
+Tipp-Box:
+```md
+> [!TIP]
+> Praktischer Tipp.
+```

--- a/docs/wiki/CI-CD.md
+++ b/docs/wiki/CI-CD.md
@@ -1,9 +1,9 @@
 # CI/CD 🤖
 
-| Workflow      | Beschreibung         |
-| ------------- | -------------------- |
-| `ci.yml`      | Linting und Tests    |
-| `preview.yml` | Docker-Preview       |
-| `docs.yml`    | Doku-Automatisierung |
+| Workflow | Beschreibung |
+|---|---|
+| `ci.yml` | Linting und Tests |
+| `preview.yml` | Docker-Preview |
+| `docs.yml` | Doku-Automatisierung |
 
 <span style="color:purple">Automatisierte Abläufe sorgen für Qualität.</span>

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,7 +1,12 @@
 # Contributing 🤝
 
+> [!WARNING]
+> Direkte Commits auf main sind nicht erlaubt.
 1. Fork & Branch anlegen
 2. Tests/Linter laufen lassen
 3. Pull Request erstellen
 
-<span style="color:blue">Bitte Prettier und ESLint beachten.</span>
+> [!TIP]
+> Bitte Prettier und ESLint beachten.
+
+Siehe den [Styleguide](../style-guide.md).

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -2,25 +2,25 @@
 
 HTML/CSS/JS Template mit automatischen Linter- und Formatierungs-Checks
 
-| Metadatum       | Wert  |
-| --------------- | ----- |
-| Version         | 1.0.0 |
-| Kommentarzeilen | 1     |
+👉 Siehe den [Styleguide](../style-guide.md).
+
+| Metadatum | Wert |
+|---|---|
+| Version | 1.0.0 |
+| Kommentarzeilen | 1 |
 
 > change the text "current theme: light" into "current theme: dark"
 
 ## Architektur
+| Datei | Beschreibung |
+|---|---|
+| `index.html` | Einstieg & Markup |
+| `index.css` | Basis-Styling |
+| `index.js` | Theme-Toggle-Logik |
 
-| Datei        | Beschreibung       |
-| ------------ | ------------------ |
-| `index.html` | Einstieg & Markup  |
-| `index.css`  | Basis-Styling      |
-| `index.js`   | Theme-Toggle-Logik |
-
-<span style="color:green">Dieses Wiki wird automatisch aus dem Code erzeugt.</span>
+![Autogeneriert](https://img.shields.io/badge/Autogeneriert-green)
 
 ## Kapitel
-
 - [[Installation]]
 - [[Usage]]
 - [[CI-CD]]

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,8 +1,10 @@
 # Installation ⚙️
 
-| Befehl         | Zweck                     |
-| -------------- | ------------------------- |
-| `npm install`  | Dependencies installieren |
-| `npm run lint` | Linting ausführen         |
+| Befehl | Zweck |
+|---|---|
+| `npm install` | Dependencies installieren |
+| `npm run lint` | Linting ausführen |
 
-<span style="color:orange">Tipp:</span> Node.js >= 20 verwenden.
+> [!TIP]
+> Node.js >= 20 verwenden.
+

--- a/docs/wiki/Usage.md
+++ b/docs/wiki/Usage.md
@@ -1,9 +1,8 @@
 # Usage ▶️
 
 ## Skripte
-
 | `lint:html` | htmlhint . |
-| `lint:css` | stylelint "\*_/_.css" |
+| `lint:css` | stylelint "**/*.css" |
 | `lint:js` | eslint . --max-warnings=0 |
 | `lint` | npm run lint:html && npm run lint:css && npm run lint:js |
 | `fmt` | prettier -w . |

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -85,6 +85,12 @@ console.log('Context written to repo_context.txt')
 
 // --- Wiki generation -------------------------------------------------------
 
+// Predefined Markdown components
+const md = {
+  warning: (text) => `> [!WARNING]\n> ${text}\n`,
+  tip: (text) => `> [!TIP]\n> ${text}\n`,
+}
+
 /**
  * Extract single line comments from the given files.
  * Currently supports "//" comments in JS files.
@@ -133,11 +139,11 @@ function buildWiki() {
     '| `index.js` | Theme-Toggle-Logik |',
   ].join('\n')
 
-  const homeContent = `# Wiki – ${pkg.name || ''}\n\n${pkg.description || ''}\n\n| Metadatum | Wert |\n|---|---|\n| Version | ${
+  const homeContent = `# Wiki – ${pkg.name || ''}\n\n${pkg.description || ''}\n\n\uD83D\uDC49 Siehe den [Styleguide](../style-guide.md).\n\n| Metadatum | Wert |\n|---|---|\n| Version | ${
     pkg.version || '0.0.0'
-  } |\n| Kommentarzeilen | ${comments.length} |\n\n${commentBlock}\n\n## Architektur\n${architectureTable}\n\n<span style="color:green">Dieses Wiki wird automatisch aus dem Code erzeugt.</span>\n\n## Kapitel\n- [[Installation]]\n- [[Usage]]\n- [[CI-CD]]\n- [[Contributing]]\n`
+  } |\n| Kommentarzeilen | ${comments.length} |\n\n${commentBlock}\n\n## Architektur\n${architectureTable}\n\n![Autogeneriert](https://img.shields.io/badge/Autogeneriert-green)\n\n## Kapitel\n- [[Installation]]\n- [[Usage]]\n- [[CI-CD]]\n- [[Contributing]]\n`
 
-  const installContent = `# Installation ⚙️\n\n| Befehl | Zweck |\n|---|---|\n| \`npm install\` | Dependencies installieren |\n| \`npm run lint\` | Linting ausführen |\n\n<span style="color:orange">Tipp:</span> Node.js \>= 20 verwenden.\n`
+  const installContent = `# Installation ⚙️\n\n| Befehl | Zweck |\n|---|---|\n| \`npm install\` | Dependencies installieren |\n| \`npm run lint\` | Linting ausführen |\n\n${md.tip('Node.js >= 20 verwenden.')}\n`
 
   const cicdTable = [
     '| Workflow | Beschreibung |',
@@ -153,7 +159,7 @@ function buildWiki() {
     .readFileSync('index.js', 'utf8')
     .trim()}\n\`\`\`\n`
 
-  const contribContent = `# Contributing 🤝\n\n1. Fork & Branch anlegen\n2. Tests/Linter laufen lassen\n3. Pull Request erstellen\n\n<span style="color:blue">Bitte Prettier und ESLint beachten.</span>\n`
+  const contribContent = `# Contributing 🤝\n\n${md.warning('Direkte Commits auf main sind nicht erlaubt.')}1. Fork & Branch anlegen\n2. Tests/Linter laufen lassen\n3. Pull Request erstellen\n\n${md.tip('Bitte Prettier und ESLint beachten.')}\nSiehe den [Styleguide](../style-guide.md).\n`
 
   fs.writeFileSync(path.join(wikiDir, 'Home.md'), homeContent)
   fs.writeFileSync(path.join(wikiDir, 'Installation.md'), installContent)


### PR DESCRIPTION
## Summary
- document headings, emojis, badges and code snippets in new style guide
- provide warning and tip components for wiki generator and link to style guide
- mention style guide in README and generated wiki pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dd5fdbf488323b7c967faf2875973