### PR TITLE
Use single 'dark' class for theme toggle

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-// change the text "current theme: light" into "current theme: dark"
+// Toggle between light and dark mode by adding/removing the "dark" class on
+// the body element and updating the theme indicator text.
 
 const themeIndicator = document.getElementById('theme-indicator')
 const toggleBtn = document.getElementById('toggle-btn')
 let isDarkMode = false
 toggleBtn.addEventListener('click', () => {
   isDarkMode = !isDarkMode
-  document.body.classList.toggle('dark-mode', isDarkMode)
+  document.body.classList.toggle('dark', isDarkMode)
   themeIndicator.textContent = `Current Theme: ${isDarkMode ? 'Dark' : 'Light'}`
-  document.body.classList.toggle('dark')
 })


### PR DESCRIPTION
## Summary
- remove unused `dark-mode` class and toggle only `dark`
- clarify top comment about theme toggling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de44b9aa483239b273f97ddeae959