### PR TITLE
ci: run npm fmt after tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,5 @@ jobs:
       # ---- Tests (falls vorhanden) ----
       - name: Unit tests
         run: npm test --if-present
+      - name: Format
+        run: npm run fmt


### PR DESCRIPTION
## Summary
- add formatting step to CI workflow so code is formatted after running unit tests

## Testing
- `npm test`
- `npm run fmt`


------
https://chatgpt.com/codex/tasks/task_e_689df25b4e5083239120c514fe0107c2