### PR TITLE
chore(ci): add npm audit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
             npm install --legacy-peer-deps
           fi
 
+      - name: Security audit
+        run: npm audit --audit-level=moderate
+
       # ---- Linting & Format ----
       - name: Lint HTML
         run: npm run lint:html


### PR DESCRIPTION
## Summary
- run `npm audit --audit-level=moderate` after installing dependencies to fail PRs with moderate or higher vulnerabilities

## Testing
- `npm run lint:html`
- `npm run lint:css`
- `npm run lint:js`
- `npm run fmt:check`
- `npm test`
- `npm audit --audit-level=moderate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689df706cb8483239016f0923709a35e