### PR TITLE
docs: add project documentation sections and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,46 @@ Dies ist die Basisstruktur für das GitHub CI/CD Template `html-template-se`.
 - Mini-Demo: Dark Mode Toggle mit HTML/CSS/JS
 - Workflows: `.github/workflows/preview.yml` (für Testing + GitHub Pages Preview)
 
-## Demo-Funktion
+## Features
 
-Einfacher Dark-Mode-Toggle per Button.
+- Einfacher Dark-Mode-Button mit HTML/CSS/JS
+- Linting- und Formatierungs-Skripte für HTML, CSS und JavaScript
+- Automatisches Deployment einer Preview via GitHub Actions
 
-## Dokumentation generieren
-
-Kopiere die README in das Verzeichnis `docs`:
+## Installation
 
 ```bash
-node scripts/generate-docs.mjs
+git clone <repo>
+cd html-template-se
+npm install
 ```
+
+## Nutzung
+
+- Öffne `index.html` im Browser, um die Demo zu sehen.
+- Linting prüfen: `npm run lint`
+- Dokumentation generieren: `node scripts/generate-docs.mjs` kopiert die README nach `docs/`.
+
+## CI/CD
+
+Die GitHub Actions Workflow-Datei `.github/workflows/preview.yml` führt Linting aus und veröffentlicht eine GitHub Pages Preview.
+
+## Ordnerstruktur
+
+```
+.
+├── docs/                # generierte Dokumentation
+├── scripts/             # Hilfsskripte
+├── index.html           # Startseite
+├── index.css            # Styles
+├── index.js             # JS-Logik (Dark-Mode-Toggle)
+├── .github/workflows/   # CI/CD Workflows
+└── ...
+```
+
+## License
+
+Dieses Projekt steht unter der MIT License. Weitere Details in [LICENSE](LICENSE).
 
 ## Nächste Schritte
 


### PR DESCRIPTION
## Summary
- expand README with features, installation, usage, CI/CD, folder structure, and license sections
- add MIT license file and reference it in documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df9a1bcdc83239b4522b34dd430c1