### PR TITLE
ci: simplify jq installation in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,9 +53,7 @@ jobs:
 
       - name: Install jq
         if: steps.secretcheck.outputs.missing == 'false'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y jq
+        run: sudo apt-get install -y jq
 
       - name: Collect repository context
         if: steps.secretcheck.outputs.missing == 'false'


### PR DESCRIPTION
## Summary
- simplify jq install step by dropping redundant `apt-get update`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dfd30507c8323a6c031e15bae281b